### PR TITLE
refactor: rename API endpoints and change ApiError property serialization

### DIFF
--- a/Trackr.API/Controllers/TransactionController.cs
+++ b/Trackr.API/Controllers/TransactionController.cs
@@ -23,7 +23,7 @@ public class TransactionController : ControllerBase
     }
 
     [Authorize]
-    [HttpGet("GetUserTransactions")]
+    [HttpGet]
     public async Task<List<Transaction>> GetUserTransactions(int count, int page, CancellationToken cancellationToken)
     {
         var id = CredentialRetriever.GetUserId(HttpContext);
@@ -32,7 +32,7 @@ public class TransactionController : ControllerBase
     }
 
     [Authorize]
-    [HttpPost("AddTransaction")]
+    [HttpPost]
     [Produces("application/json")]
     public async Task<Transaction> Add(TransactionRequestModel transaction, CancellationToken cancellationToken)
     {
@@ -42,7 +42,7 @@ public class TransactionController : ControllerBase
     }
 
     [Authorize]
-    [HttpGet("GetLatestTransaction")]
+    [HttpGet("latest-transactions")]
     [Produces("application/json")]
     public async Task<List<Transaction>> GetLatestTransaction(int transactionCount, CancellationToken cancellationToken)
     {
@@ -52,7 +52,7 @@ public class TransactionController : ControllerBase
     }
 
     [Authorize]
-    [HttpDelete("DeleteTransaction/{transactionId}")]
+    [HttpDelete("{transactionId}")]
     [Produces("application/json")]
     public async Task<Transaction> DeleteTransaction(Guid transactionId, CancellationToken cancellationToken)
     {
@@ -62,7 +62,7 @@ public class TransactionController : ControllerBase
     }
 
     [Authorize]
-    [HttpPut("EditTransaction/{transactionId}")]
+    [HttpPut("{transactionId}")]
     [Produces("application/json")]
     public async Task<Transaction> EditTransaction(TransactionRequestModel newTransaction, Guid transactionId
 , CancellationToken cancellationToken)
@@ -73,7 +73,7 @@ public class TransactionController : ControllerBase
     }
 
     [Authorize]
-    [HttpGet("GetMoneySpent")]
+    [HttpGet("money-spent")]
     [Produces("application/json")]
     public async Task<MoneySpentModel> GetMoneySpent(CancellationToken cancellationToken)
     {
@@ -83,7 +83,7 @@ public class TransactionController : ControllerBase
     }
 
     [Authorize]
-    [HttpGet("GetPreviousAndCurrentMonthExpenses")]
+    [HttpGet("previous-and-current-month")]
     [Produces("application/json")]
     public async Task<CurrentAndPreviousMonthExpensesModel> GetCurrentAndPreviousMonthExpenses(CancellationToken cancellationToken)
     {
@@ -93,7 +93,7 @@ public class TransactionController : ControllerBase
     }
 
     [Authorize]
-    [HttpGet("GetExpensesForTheWholeYear")]
+    [HttpGet("yearly-expense")]
     [Produces("application/json")]
     public async Task<SortedDictionary<int, decimal>> GetExpensesOfTheWholeYear(CancellationToken cancellationToken)
     {

--- a/Trackr.API/Controllers/UserController.cs
+++ b/Trackr.API/Controllers/UserController.cs
@@ -13,7 +13,7 @@ namespace Trackr.API.Controllers;
 
 [ApiController]
 [ApiVersion(1)]
-[Route("/v{version:apiversion}/User")]
+[Route("/v{version:apiversion}/[controller]")]
 public class UserController : ControllerBase
 {
     private IUserService _userService;
@@ -23,7 +23,7 @@ public class UserController : ControllerBase
         _userService = userService;
     }
 
-    [HttpPost("Register")]
+    [HttpPost("register")]
     public async Task<UserResponseModel> Register([FromBody] UserRequestModel user, CancellationToken cancellationToken)
     {
         UserResponseModel res = await _userService.Register(user, cancellationToken);
@@ -31,7 +31,7 @@ public class UserController : ControllerBase
         return res;
     }
 
-    [HttpPost("Login")]
+    [HttpPost("login")]
     public async Task<string> Login([FromBody] UserLoginRequestModel user, CancellationToken cancellationToken)
     {
         string res = await _userService.Login(user, cancellationToken);
@@ -39,7 +39,7 @@ public class UserController : ControllerBase
     }
 
     [Authorize]
-    [HttpPatch("UpdateCostLimit")]
+    [HttpPatch("cost-limit")]
     public async Task<UserResponseModel> UpdateCostLimit([FromBody] CostLimitModel costLimit, CancellationToken cancellationToken)
     {
         var id = CredentialRetriever.GetUserId(HttpContext);
@@ -48,7 +48,7 @@ public class UserController : ControllerBase
     }
 
     [Authorize]
-    [HttpGet("GetBalance")]
+    [HttpGet("balance")]
     public async Task<BalanceModel> GetBalance(CancellationToken cancellationToken)
     {
         var id = CredentialRetriever.GetUserId(HttpContext);
@@ -57,7 +57,7 @@ public class UserController : ControllerBase
     }
 
     [Authorize]
-    [HttpPatch("UpdateBalance")]
+    [HttpPatch("balance")]
     public async Task<UserResponseModel> UpdateBalance(BalanceModel newBalance, CancellationToken cancellationToken)
     {
         var id = CredentialRetriever.GetUserId(HttpContext);

--- a/Trackr.API/Infrastructure/Errors/APIError.cs
+++ b/Trackr.API/Infrastructure/Errors/APIError.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System.Net;
+using System.Text.Json.Serialization;
 using Trackr.Application.Exceptions;
 
 namespace Trackr.API.Infrastructure.Errors;
@@ -7,21 +8,24 @@ namespace Trackr.API.Infrastructure.Errors;
 public class APIError : ProblemDetails
 {
     private const string _unhandledErrorCode = "UnhandledErrorCode";
-    
+    private string? traceId;
+
     // ReSharper disable once UnusedAutoPropertyAccessor.Global
+    [JsonPropertyName("code")]
     public string Code { get; set; }
 
+    [JsonPropertyName("traceId")]
     public string? TraceId
     {
         get
         {
-            if (Extensions.TryGetValue("TraceId", out var traceId))
+            if (Extensions.TryGetValue("traceId", out var traceId))
             {
                 return (string?)traceId;
             }
             return null;
         }
-        set => Extensions["TraceId"] = value;
+        set => Extensions["traceId"] = value;
     }
 
     public APIError(HttpContext ctx, Exception ex)

--- a/Trackr.API/Infrastructure/Extensions/SwaggerExtensions.cs
+++ b/Trackr.API/Infrastructure/Extensions/SwaggerExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.OpenApi.Models;
+using Trackr.API.Infrastructure.Helpers;
 
 namespace Trackr.API.Infrastructure.Extensions;
 
@@ -7,7 +9,10 @@ public static class SwaggerExtensions
 {
     public static IServiceCollection ConfigureSwagger(this IServiceCollection services)
     {
-        services.AddControllers();
+        services.AddControllers(options =>
+        {
+            options.Conventions.Add(new RouteTokenTransformerConvention(new ControllerNameTransformer()));
+        });
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen(x =>
         {

--- a/Trackr.API/Infrastructure/Helpers/ControllerNameTransformer.cs
+++ b/Trackr.API/Infrastructure/Helpers/ControllerNameTransformer.cs
@@ -1,0 +1,9 @@
+﻿namespace Trackr.API.Infrastructure.Helpers;
+
+public class ControllerNameTransformer : IOutboundParameterTransformer
+{
+    public string? TransformOutbound(object? value)
+    {
+        return value?.ToString()?.ToLowerInvariant();
+    }
+}


### PR DESCRIPTION
Changed:
- Renamed API endpoints to a more RESTful way
- Changed `Code` and `TraceId` not being serialized to camel case in `ApiError` 